### PR TITLE
Features/global layout previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,21 @@ Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
+=== Description ===
 Flexible Layout previews allows content editors to see an example of the layout prior to selecting it in a flexible layout section. The preview will show to the left of the ACF popup when hovering a specific layout.
 
 To use previews, the preview images may be placed inside `wp-content/themes/{theme}/layouts/previews`. The naming convention needs to follow
 `{flexible_layout_id}_{layout_id}.jpg`. (jpgs must be used).
+
+== Changelog ==
+
+= 1.1.0 =
+Enhancements:
+
+* Allow for global layout previews. Global preview naming convention is _{layout_id}.jpg.
+* Add .gitignore file.
+
+= 1.0.0 =
+Release Date: September 17th, 2021
+
+Flexible Content Previews.

--- a/admin/class-flexible-layout-previews-admin.php
+++ b/admin/class-flexible-layout-previews-admin.php
@@ -13,9 +13,6 @@
 /**
  * The admin-specific functionality of the plugin.
  *
- * Defines the plugin name, version, and two examples hooks for how to
- * enqueue the admin-specific stylesheet and JavaScript.
- *
  * @package    Flexible_Layout_Previews
  * @subpackage Flexible_Layout_Previews/admin
  * @author     Elegant Seagulls <dan@elegantseagulls.com>
@@ -55,6 +52,27 @@ class Flexible_Layout_Previews_Admin {
 	}
 
 	/**
+	 * Return the required markup to be used in filtering the ACF Layout Title.
+	 *
+	 * @since 1.1.0
+	 * @param string $layout_name The layout identifier name.
+	 * @param string $preview_url The url to the preview image.
+	 * @param string $layout_label The layout label name.
+	 *
+	 * @return string The required markup.
+	 */
+	private function get_preview_title_markup( $layout_name, $preview_url, $layout_label ) {
+		$html  = '<span class="es-acf-fc-preview no-preview"';
+		$html .= ' data-layout="' . $layout_name . '"';
+		$html .= ' data-preview="' . $preview_url . '"';
+		$html .= '>';
+		$html .= $layout_label;
+		$html .= '</span>';
+
+		return $html;
+	}
+
+	/**
 	 * Checks if the current flexible layout has a preview image available.
 	 * If there is a image available, modifies the title to include html
 	 * markup for the preview URL.
@@ -73,16 +91,16 @@ class Flexible_Layout_Previews_Admin {
 		$layout_slug       = $page_builder_name . '_' . $layout_name;
 		$layout_label      = $layout['label'];
 
-		$preview_relative = get_template_directory() . '/layouts/previews/' . $layout_slug . '.jpg';
-		$preview_url      = get_template_directory_uri() . '/layouts/previews/' . $layout_slug . '.jpg';
+		$preview_relative        = get_template_directory() . '/layouts/previews/' . $layout_slug . '.jpg';
+		$preview_global_relative = get_template_directory() . '/layouts/previews/_' . $layout_name . '.jpg';
 
+		// Check if a specific preview is set for the page builder and component.
 		if ( file_exists( $preview_relative ) ) {
-			$title  = '<span class="es-acf-fc-preview no-preview"';
-			$title .= ' data-layout="' . $layout_name . '"';
-			$title .= ' data-preview="' . $preview_url . '"';
-			$title .= '>';
-			$title .= $layout_label;
-			$title .= '</span>';
+			$preview_url = get_template_directory_uri() . '/layouts/previews/' . $layout_slug . '.jpg';
+			$title       = $this->get_preview_title_markup( $layout_name, $preview_url, $layout_label );
+		} elseif ( file_exists( $preview_global_relative ) ) { // Check if there is a global component preview set.
+			$preview_url = get_template_directory_uri() . '/layouts/previews/_' . $layout_name . '.jpg';
+			$title       = $this->get_preview_title_markup( $layout_name, $preview_url, $layout_label );
 		}
 
 		return $title;

--- a/flexible-layout-previews.php
+++ b/flexible-layout-previews.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Flexible Layout Previews
  * Plugin URI:        https://elegantseagulls.com
  * Description:       Allows you to save images for previews to display to content editors when they are selecting new Flexible Layouts.
- * Version:           1.0.0
+ * Version:           1.1.0
  * Author:            Elegant Seagulls
  * Author URI:        https://elegantseagulls.com
  * License:           GPL-2.0+
@@ -27,7 +27,7 @@ if ( ! defined( 'WPINC' ) ) {
 /**
  * Currently plugin version (uses SemVer).
  */
-define( 'FLEXIBLE_LAYOUT_PREVIEWS_VERSION', '1.0.0' );
+define( 'FLEXIBLE_LAYOUT_PREVIEWS_VERSION', '1.1.0' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
- Update readme
- Allow for global layout previews

Example: 

Home page builder id is `home_page_builder`. It has 2 global layouts and 1 unique layout.

Instead of having the following files
```
home_page_builder_global_layout_1.jpg
home_page_builder_global_layout_2.jg
home_page_builder_unique_layout.jpg
```

and possibly

```
page_builder_global_layout_1.jpg (same as home page global layout 1)
page_builder_global_layout_2.jpg (same as home page global layout 2)
```

you can just have

```
_global_layout_1.jpg
_global_layout_2.jpg
home_page_builder_unique_layout.jpg
```